### PR TITLE
Type mismatches, `auto_join_channel` implemented, and add channels filter

### DIFF
--- a/tap_slack/schemas/channels.py
+++ b/tap_slack/schemas/channels.py
@@ -7,10 +7,10 @@ schema = th.PropertiesList(
     th.Property("is_group", th.BooleanType),
     th.Property("is_im", th.BooleanType),
     th.Property("created", th.StringType),
-    th.Property("creator", th.StringType),
+    th.Property("creator", th.IntegerType),
     th.Property("is_archived", th.BooleanType),
     th.Property("is_general", th.BooleanType),
-    th.Property("unlinked", th.StringType),
+    th.Property("unlinked", th.IntegerType),
     th.Property("name_normalized", th.StringType),
     th.Property("is_shared", th.BooleanType),
     th.Property("is_ext_shared", th.BooleanType),
@@ -28,7 +28,7 @@ schema = th.PropertiesList(
         th.ObjectType(
             th.Property("value", th.StringType),
             th.Property("creator", th.StringType),
-            th.Property("last_set", th.StringType),
+            th.Property("last_set", th.IntegerType),
         ),
     ),
     th.Property(
@@ -36,7 +36,7 @@ schema = th.PropertiesList(
         th.ObjectType(
             th.Property("value", th.StringType),
             th.Property("creator", th.StringType),
-            th.Property("last_set", th.StringType),
+            th.Property("last_set", th.IntegerType),
         ),
     ),
     th.Property("previous_names", th.ArrayType(th.StringType)),

--- a/tap_slack/schemas/channels.py
+++ b/tap_slack/schemas/channels.py
@@ -7,7 +7,7 @@ schema = th.PropertiesList(
     th.Property("is_group", th.BooleanType),
     th.Property("is_im", th.BooleanType),
     th.Property("created", th.StringType),
-    th.Property("creator", th.IntegerType),
+    th.Property("creator", th.StringType),
     th.Property("is_archived", th.BooleanType),
     th.Property("is_general", th.BooleanType),
     th.Property("unlinked", th.IntegerType),

--- a/tap_slack/schemas/channels.py
+++ b/tap_slack/schemas/channels.py
@@ -6,7 +6,7 @@ schema = th.PropertiesList(
     th.Property("is_channel", th.BooleanType),
     th.Property("is_group", th.BooleanType),
     th.Property("is_im", th.BooleanType),
-    th.Property("created", th.StringType),
+    th.Property("created", th.IntegerType),
     th.Property("creator", th.StringType),
     th.Property("is_archived", th.BooleanType),
     th.Property("is_general", th.BooleanType),

--- a/tap_slack/schemas/messages.py
+++ b/tap_slack/schemas/messages.py
@@ -4,7 +4,7 @@ schema = th.PropertiesList(
     th.Property("channel_id", th.StringType, required=True),
     th.Property(
         "ts",
-        th.NumberType,
+        th.StringType,
         required=True,
         description="Epoch timestamp of when the thread reply was posted.",
     ),

--- a/tap_slack/schemas/messages.py
+++ b/tap_slack/schemas/messages.py
@@ -25,7 +25,7 @@ schema = th.PropertiesList(
             th.Property("id", th.StringType),
             th.Property("name", th.StringType),
             th.Property("team_id", th.StringType),
-            th.Property("updated", th.StringType),
+            th.Property("updated", th.IntegerType),
         ),
     ),
     th.Property("client_msg_id", th.StringType),

--- a/tap_slack/streams.py
+++ b/tap_slack/streams.py
@@ -32,7 +32,7 @@ class ChannelsStream(SlackStream):
     def post_process(self, row, context):
         "Join the channel if not a member, but emit no data."
         row = super().post_process(row, context)
-        # only return selected channels and default to all
+        # return all in selected_channels or default to all, exclude any in excluded_channels list
         channel_name = row["id"]
         if self._is_included(channel_name) and not self._is_excluded(channel_name):
             if not row["is_member"] and self.config.get("auto_join_channels", False):
@@ -40,7 +40,7 @@ class ChannelsStream(SlackStream):
             return row
 
     def _is_excluded(self, channel_name: str) -> bool:
-        excluded_channels = self.config.get("excluded_channels")
+        excluded_channels = self.config.get("excluded_channels", [])
         if channel_name in excluded_channels:
             return True
         else:

--- a/tap_slack/streams.py
+++ b/tap_slack/streams.py
@@ -34,22 +34,19 @@ class ChannelsStream(SlackStream):
         row = super().post_process(row, context)
         # return all in selected_channels or default to all, exclude any in excluded_channels list
         channel_id = row["id"]
-        if self._is_channel_inluded(channel_id) and not self._is_channel_excluded(channel_id):
+        if self._is_channel_included(channel_id):
             if not row["is_member"] and self.config.get("auto_join_channels", False):
                 self._join_channel(channel_id)
             return row
 
-    def _is_channel_excluded(self, channel_id: str) -> bool:
-        excluded_channels = self.config.get("excluded_channels", [])
-        if channel_id in excluded_channels:
-            return True
-        else:
-            return False
-
-    def _is_channel_inluded(self, channel_id: str) -> bool:
+    def _is_channel_included(self, channel_id: str) -> bool:
         selected_channels = self.config.get("selected_channels")
         if not selected_channels or channel_id in selected_channels:
-            return True
+            excluded_channels = self.config.get("excluded_channels", [])
+            if channel_id in excluded_channels:
+                return False
+            else:
+                return True
         else:
             return False
 

--- a/tap_slack/streams.py
+++ b/tap_slack/streams.py
@@ -33,22 +33,22 @@ class ChannelsStream(SlackStream):
         "Join the channel if not a member, but emit no data."
         row = super().post_process(row, context)
         # return all in selected_channels or default to all, exclude any in excluded_channels list
-        channel_name = row["id"]
-        if self._is_included(channel_name) and not self._is_excluded(channel_name):
+        channel_id = row["id"]
+        if self._is_channel_inluded(channel_id) and not self._is_channel_excluded(channel_id):
             if not row["is_member"] and self.config.get("auto_join_channels", False):
-                self._join_channel(channel_name)
+                self._join_channel(channel_id)
             return row
 
-    def _is_excluded(self, channel_name: str) -> bool:
+    def _is_channel_excluded(self, channel_id: str) -> bool:
         excluded_channels = self.config.get("excluded_channels", [])
-        if channel_name in excluded_channels:
+        if channel_id in excluded_channels:
             return True
         else:
             return False
 
-    def _is_included(self, channel_name: str) -> bool:
+    def _is_channel_inluded(self, channel_id: str) -> bool:
         selected_channels = self.config.get("selected_channels")
-        if not selected_channels or channel_name in selected_channels:
+        if not selected_channels or channel_id in selected_channels:
             return True
         else:
             return False

--- a/tap_slack/streams.py
+++ b/tap_slack/streams.py
@@ -33,11 +33,12 @@ class ChannelsStream(SlackStream):
         "Join the channel if not a member, but emit no data."
         row = super().post_process(row, context)
         # only return selected channels and default to all
-        channels = self.config.get("channels")
-        if (not channels or row["id"] in channels):
+        selected_channels = self.config.get("channels")
+        channel_name = row["id"]
+        if not selected_channels or channel_name in selected_channels:
             if not row["is_member"]:
                 if self.config.get("auto_join_channels", False):
-                    self._join_channel(row["id"])
+                    self._join_channel(channel_name)
             return row
 
     def _join_channel(self, channel_id: str) -> requests.Response:

--- a/tap_slack/streams.py
+++ b/tap_slack/streams.py
@@ -32,9 +32,13 @@ class ChannelsStream(SlackStream):
     def post_process(self, row, context):
         "Join the channel if not a member, but emit no data."
         row = super().post_process(row, context)
-        if not row["is_member"]:
-            self._join_channel(row["id"])
-        return row
+        # only return selected channels and default to all
+        channels = self.config.get("channels")
+        if (not channels or row["id"] in channels):
+            if not row["is_member"]:
+                if self.config.get("auto_join_channels", False):
+                    self._join_channel(row["id"])
+            return row
 
     def _join_channel(self, channel_id: str) -> requests.Response:
         url = f"{self.url_base}/conversations.join"

--- a/tap_slack/streams.py
+++ b/tap_slack/streams.py
@@ -34,16 +34,24 @@ class ChannelsStream(SlackStream):
         row = super().post_process(row, context)
         # only return selected channels and default to all
         channel_name = row["id"]
-        if self._do_sync_channel(channel_name):
+        if self._is_included(channel_name) and not self._is_excluded(channel_name):
             if not row["is_member"] and self.config.get("auto_join_channels", False):
                 self._join_channel(channel_name)
             return row
 
-    def _do_sync_channel(self, channel_name: str) -> bool:
-        selected_channels = self.config.get("channels")
+    def _is_excluded(self, channel_name: str) -> bool:
+        excluded_channels = self.config.get("excluded_channels")
+        if channel_name in excluded_channels:
+            return True
+        else:
+            return False
+
+    def _is_included(self, channel_name: str) -> bool:
+        selected_channels = self.config.get("selected_channels")
         if not selected_channels or channel_name in selected_channels:
             return True
-        return False
+        else:
+            return False
 
     def _join_channel(self, channel_id: str) -> requests.Response:
         url = f"{self.url_base}/conversations.join"

--- a/tap_slack/streams.py
+++ b/tap_slack/streams.py
@@ -41,14 +41,12 @@ class ChannelsStream(SlackStream):
 
     def _is_channel_included(self, channel_id: str) -> bool:
         selected_channels = self.config.get("selected_channels")
-        if not selected_channels or channel_id in selected_channels:
-            excluded_channels = self.config.get("excluded_channels", [])
-            if channel_id in excluded_channels:
+        excluded_channels = self.config.get("excluded_channels", [])
+        if channel_id in excluded_channels:
                 return False
-            else:
-                return True
-        else:
-            return False
+        if selected_channels and channel_id not in selected_channels:
+                return False
+        return True
 
     def _join_channel(self, channel_id: str) -> requests.Response:
         url = f"{self.url_base}/conversations.join"

--- a/tap_slack/tap.py
+++ b/tap_slack/tap.py
@@ -59,9 +59,14 @@ class TapSlack(Tap):
             description="Whether the bot user should attempt to join channels that it has not yet joined. The bot user must be a member of the channel to retrieve messages.",
         ),
         th.Property(
-            "channels",
+            "selected_channels",
             th.ArrayType(th.StringType),
             description="A list of channel IDs that should be retrieved. If not defined then all are selected.",
+        ),
+        th.Property(
+            "excluded_channels",
+            th.ArrayType(th.StringType),
+            description="A list of channel IDs that should not be retrieved. Excluding overrides a selected setting, so if a channel is included in both selected and excluded, it will be excluded.",
         ),
     ).to_dict()
 

--- a/tap_slack/tap.py
+++ b/tap_slack/tap.py
@@ -58,6 +58,11 @@ class TapSlack(Tap):
             default=False,
             description="Whether the bot user should attempt to join channels that it has not yet joined. The bot user must be a member of the channel to retrieve messages.",
         ),
+        th.Property(
+            "channels",
+            th.ArrayType(th.StringType),
+            description="A list of channel IDs that should be retrieved. If not defined then all are selected.",
+        ),
     ).to_dict()
 
     def discover_streams(self) -> List[Stream]:
@@ -71,3 +76,6 @@ class TapSlack(Tap):
             "tap__discovery",
             "tap__stream_connections",
         ]
+
+if __name__ == "__main__":
+    TapSlack.cli()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2,6 +2,7 @@
 
 import pytest
 import os
+from unittest.mock import patch
 
 from tap_slack.tap import TapSlack
 from tap_slack.testing import TapTestUtility
@@ -29,3 +30,17 @@ def test_builtin_tap_tests(test_util, test_config):
     test_name, params = test_config
     test_func = test_util.available_tests[test_name]
     test_func(**params)
+
+
+@patch("tap_slack.streams.ChannelsStream._join_channel")
+def test_auto_join_channel_false(patch_obj, test_util):
+    test_utility.run_sync()
+    patch_obj.assert_not_called()
+
+@patch("tap_slack.streams.ChannelsStream._join_channel")
+def test_auto_join_channel(patch_obj, test_util):
+    config = SAMPLE_CONFIG.copy()
+    config["auto_join_channels"] = True
+    test_utility = TapTestUtility(TapSlack, config, stream_record_limit=500)
+    test_utility.run_sync()
+    patch_obj.assert_called()


### PR DESCRIPTION
- I was using this tap in https://gitlab.com/meltano/squared and got some type mismatch errors from my target. This should fix all that I saw. I didnt test threads though.
- The `auto_join_channel` config was available but it wasnt being used anywhere yet so I implemented it in `post_process`
- The [non-SDK alternative](https://github.com/Mashey/tap-slack) gives you an option to only target specific channel IDs. I needed that functionality for my use case so I added it here. It defaults to sync all as it did before but if you provide the `channels` config list then it will only emit records in those channels. `post_process` still felt like the right place for this since the API doesnt have a channel filter parameter and not returning channels here worked to not traverse deeper into child streams.

What do you think? Any issues with these updates?