### PR TITLE
Bugfix/replication key

### DIFF
--- a/tap_slack/streams.py
+++ b/tap_slack/streams.py
@@ -137,9 +137,9 @@ class MessagesStream(SlackStream):
         state = self.get_context_state(context)
         replication_key_value = state.get("replication_key_value")
         if replication_key_value:
-            if self.threads_stream_start < self.threads_stream_start:
+            if self.threads_stream_start < float(replication_key_value):
                 return self.threads_stream_start
-            return replication_key_value
+            return float(replication_key_value)
         elif "start_date" in self.config:
             start_date = cast(datetime, pendulum.parse(self.config["start_date"]))
             return start_date.replace(tzinfo=timezone.utc).timestamp()

--- a/tap_slack/testing.py
+++ b/tap_slack/testing.py
@@ -323,15 +323,15 @@ class TapTestUtility(object):
         for record in self.records[stream_name]:
             r = record["record"]
             if r.get(attribute_name) is not None:
-                assert int(
-                    r[attribute_name]
-                ), f"Unable to cast value ('{r[attribute_name]}') to int type."
+                assert isinstance(
+                    int(r[attribute_name]), int
+                ), f"Unable to cast value ('{r[attribute_name]}') to int type for stream '{stream_name}'."
 
     def _test_stream_attribute_is_number(self, stream_name: str, attribute_name: str):
         "Test that a given attribute can be converted to a floating point number type."
         for record in self.records[stream_name]:
             r = record["record"]
             if r.get(attribute_name) is not None:
-                assert float(
-                    r.get(attribute_name)
+                assert isinstance(
+                    float(r.get(attribute_name)), float
                 ), f"Unable to cast value ('{r[attribute_name]}') to float type."


### PR DESCRIPTION
The replication key wasn't being used because the self.threads_stream_start looks like it was accidentally referenced twice and the property uses current time so it was always resulting in True and not getting to the replication_key_value.

Also the tests failed for me locally because `assert 0` fails so when theres an int value of `0` it fails even though it was able to cast to an int `assert int(0)`. I just swapped it over to using an `isinstance` instead.